### PR TITLE
Fixed constructor type for PyModule and PyObject

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,13 @@
 export class PyModule
 {
     private _type: 'PyModule';
-    private constructor() {}
+    private constructor();
 }
 
 export class PyObject
 {
     private _type: 'PyObject';
-    private constructor() {}
+    private constructor();
 }
 
 export interface Interpreter


### PR DESCRIPTION
Types need to be fixed to be able to be compiled in typescript.